### PR TITLE
Fix datatype issue for intervals

### DIFF
--- a/apps/demonstrations/tracker_application/tracker_utility/tracker_utility.c
+++ b/apps/demonstrations/tracker_application/tracker_utility/tracker_utility.c
@@ -1617,11 +1617,11 @@ uint8_t tracker_parse_cmd( uint8_t stack_id, uint8_t* payload, uint8_t* buffer_o
 
             case SET_APP_MOBILE_SCAN_INTERVAL_CMD:
             {
-                uint16_t mobile_scan_interval = 0;
+                uint32_t mobile_scan_interval = 0;
 
                 tracker_ctx.new_value_to_set = true;
 
-                mobile_scan_interval = ( uint16_t ) payload[payload_index] << 8;
+                mobile_scan_interval = ( uint32_t ) payload[payload_index] << 8;
                 mobile_scan_interval += payload[payload_index + 1];
 
                 if( ( mobile_scan_interval >= MOBILE_SCAN_INTERVAL_MIN ) &&
@@ -1632,7 +1632,7 @@ uint8_t tracker_parse_cmd( uint8_t stack_id, uint8_t* payload, uint8_t* buffer_o
                 else
                 {
                     /* Clip the value */
-                    if( payload[payload_index] < MOBILE_SCAN_INTERVAL_MIN )
+                    if( mobile_scan_interval < MOBILE_SCAN_INTERVAL_MIN )
                     {
                         tracker_ctx.mobile_scan_interval = MOBILE_SCAN_INTERVAL_MIN;
                     }
@@ -1666,11 +1666,11 @@ uint8_t tracker_parse_cmd( uint8_t stack_id, uint8_t* payload, uint8_t* buffer_o
 
             case SET_APP_STATIC_SCAN_INTERVAL_CMD:
             {
-                uint16_t static_scan_interval = 0;
+                uint32_t static_scan_interval = 0;
 
                 tracker_ctx.new_value_to_set = true;
 
-                static_scan_interval = ( uint16_t ) payload[payload_index] << 8;
+                static_scan_interval = ( uint32_t ) payload[payload_index] << 8;
                 static_scan_interval += payload[payload_index + 1];
                 static_scan_interval *= 60;
 
@@ -1682,7 +1682,7 @@ uint8_t tracker_parse_cmd( uint8_t stack_id, uint8_t* payload, uint8_t* buffer_o
                 else
                 {
                     /* Clip the value */
-                    if( payload[payload_index] < STATIC_SCAN_INTERVAL_MIN )
+                    if( static_scan_interval < STATIC_SCAN_INTERVAL_MIN )
                     {
                         tracker_ctx.static_scan_interval = STATIC_SCAN_INTERVAL_MIN;
                     }


### PR DESCRIPTION
## Issue 
Using the LoRa Edge Config mobile application.
When trying to set static_scan_interval to 1440 minutes, the value was incorrectly clipped to **347**.

## Root causes
In [tracker_utility.h](https://github.com/Lora-net/SWSD004/blob/master/apps/demonstrations/tracker_application/tracker_utility/tracker_utility.c#L1669), in the handling of BLE commands.

1. Incorrect data type
    In `SET_APP_STATIC_SCAN_INTERVAL_CMD`, the values are extracted from a buffer of `uint8_t` to a temp `uint16_t`, which is too small for internal computation.
    Thus, the computed value in seconds is clipped, leading to an incorrect setting.
    The values stored in `tracker_ctx` are correctly of type `uint32_t`, but the clipping happens before.

    Example and compiler output:
    ```C
    #include <assert.h>
    void test_casts(void) {
      uint8_t buffer[2] = {0x05, 0xA0};           // 05A0 == 1440 min == 86400 s
      uint16_t value = (uint16_t)buffer[0] << 8;  // Intermediate value
      value += buffer[1];
      value *= 60;  // XXX Result is too big for an uint16_t !
      assert(86400 == value);
    }
    ```
    ```
    In function ‘test_casts’:
    warning: comparison is always false due to limited range of data type [-Wtype-limits]
       76 |   assert(86400 == value);
          |                ^~
    ```

2. Logic error
Additionnaly, the comparison with `STATIC_SCAN_INTERVAL_MIN` and `STATIC_SCAN_INTERVAL_MAX` is directly done on the high byte of the raw payload buffer, instead of the final computed value (in seconds). See [tracker_utility.c line 1685](https://github.com/Lora-net/SWSD004/blob/master/apps/demonstrations/tracker_application/tracker_utility/tracker_utility.c#L1685).

## Fixes
This pull request fixes these two issues:

1. Incorrect data type
    Use an `uint32_t` for the intermediate value used in computations.
2. Logic error
    Use the computed value instead of the raw payload buffer.

